### PR TITLE
bump aqbanking-version for new dkb-api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get -qy update && \
   apt-get clean
 
 RUN echo && \
-  wget "https://www.aquamaniac.de/rdm/attachments/download/415/gwenhywfar-5.9.0.tar.gz" -O- | tar -xzvf- -C /usr/src/ && \
-  wget "https://www.aquamaniac.de/rdm/attachments/download/499/aqbanking-6.5.4.tar.gz" -O- | tar -xzvf- -C /usr/src/ && \
+  wget "https://www.aquamaniac.de/rdm/attachments/download/529/gwenhywfar-5.12.0.tar.gz" -O- | tar -xzvf- -C /usr/src/ && \
+  wget "https://www.aquamaniac.de/rdm/attachments/download/531/aqbanking-6.6.0.tar.gz" -O- | tar -xzvf- -C /usr/src/ && \
   cd /usr/src/gwenhywfar* && \
   make -fMakefile.cvs && \
   ./configure --prefix=/ --exec-prefix=/usr --with-guis="" && \


### PR DESCRIPTION
```
Änderung zum 25.11.2024:
Die URL für FinTS lautet https://fints.dkb.de/fints und unterstützt ab dem 25.11.2024 die drei Modi DKB-App (decoupled), chipTAN manuell, chipTAN QR. Unterstützung für ChipTAN USB oder FlickerCode entfällt.
Anscheinend ist es nötig, die BIC BYLADEM1001 manuell einzugeben, damit der Umsatzabruf funktioniert. Für TAN-Freigabe per App (decoupled) ist ein aktuelles aqbanking (>6.5.5) erforderlich.
```
Damit das funktioniert muss die aqbanking-version aktuell sein.